### PR TITLE
Change for quoted hex codes in css files

### DIFF
--- a/slimmer/slimmer.py
+++ b/slimmer/slimmer.py
@@ -232,6 +232,17 @@ def _css_slimmer(css):
     # removed. Put it back (http://real.issuetrackerproduct.com/0168)
     css = re.sub(r'voice-family:"\\"}\\""', r'voice-family: "\\"}\\""', css)
     
+    # MS quoted hex colors replacement. 
+    # Things like 
+    # filter:progid:DXImageTransform.Microsoft.gradient( startColorstr='#fff',endColorstr='#e7e7e7',GradientType=0 );
+    # Are not the same as
+    # filter:progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff',endColorstr='#e7e7e7',GradientType=0 );
+    # because they're value inputs and #FFF is blue-green and #FFFFFF is white. 
+    # Put back the full value that slimmer stirpped out when hex is quoted 
+    # Per https://github.com/peterbe/slimmer/issues/2#issuecomment-5628053
+    # Added by Jacques Favreau (@j_favreau) May 10th 2012
+    css = re.sub(r'(["\'])#(\w\w\w)(["\'])', r'\1#\2\2\3', css)
+    
     return css.strip()
 
 

--- a/slimmer/tests/codechunks.py
+++ b/slimmer/tests/codechunks.py
@@ -133,7 +133,19 @@ expect_CSS_7 = r'''
 '''
 
 #----------------------------------------------------------------------------
+CSS_8 = r'''
+div {
+height: 10px;
+background: #ffffff;
+filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c5c5c5', endColorstr='#ffffff',GradientType=0 );
+}
+'''
 
+expect_CSS_8 = r'''
+div{height:10px;background:#fff;filter:progid:DXImageTransform.Microsoft.gradient( startColorstr='#c5c5c5',endColorstr='#ffffff',GradientType=0 )}
+'''
+
+#----------------------------------------------------------------------------
 HTML_1='''
 <img src="a.gif" width="100" width="100" height='100' border=0>
 <STYLE type="text/css">

--- a/slimmer/tests/testSlimmer.py
+++ b/slimmer/tests/testSlimmer.py
@@ -157,7 +157,12 @@ class SlimmerTestCase(unittest.TestCase):
     def testCSS7(self):
         before = CSS_7
         expect = expect_CSS_7
-        self.atest(before, expect, "CSS6", slimmer.css_slimmer)    
+        self.atest(before, expect, "CSS7", slimmer.css_slimmer)
+    
+    def testCSS8(self):
+        before = CSS_8
+        expect = expect_CSS_8
+        self.atest(before, expect, "CSS8", slimmer.css_slimmer)    
 
     def testHTML1(self):
         before = HTML_1


### PR DESCRIPTION
To fix up https://github.com/peterbe/slimmer/issues/2 the following changes were made to slimmer:
- Added a secondary operation, similar to the voice-family operation for unpacking quoted shortened hex codes into full hex codes after slimmer has come by.
- Added a test to verify functionality
- Changed a test name that was a typo (there were two CSS6's)

All the best,
Jacques
